### PR TITLE
アイテムの並び順の修正リクエスト（１／２）

### DIFF
--- a/script/gen-json.js
+++ b/script/gen-json.js
@@ -371,9 +371,9 @@ allItems.sort(function(a, b) {
 
 // 日本語ソート
 function conversion(str) {
+  str = hiraToKana(str);
   str = tsu_conv(str);
   str = choon_conv(str);
-  str = hiraToKana(str);
   str = daku_conv(str);
   return str;
 }


### PR DESCRIPTION
促音の変換（ッ→ツ）前にひらがな→カタカナ変換を行うようにして
促音を含むひらがな・カタカナアイテムの並び順を実機に合わせた

ポスターの例：
　ガチコンプ： かっぺい→カックン→カットリーヌ
　実機： カックン→カットリーヌ→かっぺい

アクセサリーの例：
　カチコンプ： はっぱ→パック
　実機：　パック→はっぱ