### PR TITLE
アイテムの並び順の修正リクエスト（２／２）

### DIFF
--- a/script/gen-json.js
+++ b/script/gen-json.js
@@ -400,8 +400,8 @@ allItems.sort(function(c, d) {
 
 // 数字で始まるアイテムを先頭に持ってくる（例：１ごうのしゃしん）
 allItems.sort(function(a, b) {
-  const isAlfabetA = a.displayName.slice(0, 1).match(/[^０-９]/gi);
-  const isAlfabetB = b.displayName.slice(0, 1).match(/[^０-９]/gi);
+  const isAlfabetA = a.displayName.slice(0, 1).match(/[^0-9０-９]/gi);
+  const isAlfabetB = b.displayName.slice(0, 1).match(/[^0-9０-９]/gi);
   if (!isAlfabetA && isAlfabetB) {
     return -1;
   }

--- a/script/gen-json.js
+++ b/script/gen-json.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const {
   hiraToKana,
+  hanEisuToZenEisu,
   daku_conv,
   choon_conv,
   tsu_conv,
@@ -372,6 +373,7 @@ allItems.sort(function(a, b) {
 // 日本語ソート
 function conversion(str) {
   str = hiraToKana(str);
+  str = hanEisuToZenEisu(str);
   str = tsu_conv(str);
   str = choon_conv(str);
   str = daku_conv(str);
@@ -396,15 +398,15 @@ allItems.sort(function(c, d) {
   }
 });
 
-// アルファベットを日本語の後ろに
+// 数字で始まるアイテムを先頭に持ってくる（例：１ごうのしゃしん）
 allItems.sort(function(a, b) {
-  const isAlfabetA = a.displayName.slice(0, 1).match(/[^a-zA-Z]/gi);
-  const isAlfabetB = b.displayName.slice(0, 1).match(/[^a-zA-Z]/gi);
+  const isAlfabetA = a.displayName.slice(0, 1).match(/[^０-９]/gi);
+  const isAlfabetB = b.displayName.slice(0, 1).match(/[^０-９]/gi);
   if (!isAlfabetA && isAlfabetB) {
-    return 1;
+    return -1;
   }
   if (isAlfabetA && !isAlfabetB) {
-    return -1;
+    return 1;
   }
   return 0;
 });

--- a/script/gen-json.js
+++ b/script/gen-json.js
@@ -371,9 +371,9 @@ allItems.sort(function(a, b) {
 
 // 日本語ソート
 function conversion(str) {
+  str = hiraToKana(str);
   str = tsu_conv(str);
   str = choon_conv(str);
-  str = hiraToKana(str);
   str = daku_conv(str);
   return str;
 }

--- a/script/utils.js
+++ b/script/utils.js
@@ -5,6 +5,12 @@ module.exports = {
       return String.fromCharCode(chr);
     });
   },
+  hanEisuToZenEisu: function(str) {
+    return str.replace(/[A-Za-z0-9]/g, function(match) {
+      const chr = match.charCodeAt(0) + 0xFEE0;
+      return String.fromCharCode(chr);
+    });
+  },
   daku_conv: function(str) {
     str = str.normalize("NFD");
     str = str.replace(/[\u3099\u309A]/g, "");


### PR DESCRIPTION
実機のあいうえお順は
・全半角の区別なし
・ひらがな／カタカナの区別なし
・【数字】→【ひらがな／カタカナ】→【アルファベット】
のようなので、以下の処理に修正

1. 半角英数は全角英数に変換
2. 数字で始まるアイテムを先頭に持ってくる

この修正で以下のようなアイテムの並び順が実機と同じになる
・全角数字で始まるアイテム：１ごうのしゃしん
・アルファベットを含むアイテム：アイアンウッドDIYテーブル