### PR TITLE
【バグ】"Recycle box" の日本語訳修正

### DIFF
--- a/data/translation-custom/source.json
+++ b/data/translation-custom/source.json
@@ -118,7 +118,7 @@
   "Planting an orange": "オレンジを植える",
   "Pretty Good Tools Recipes": "フツーにつかえる！どうぐレシピ",
   "Recycle bin": "メッセージボトル",
-  "Recycle box": "メッセージボトル",
+  "Recycle box": "リサイクルボックス",
   "Redd's Raffle": "いなりくじ",
   "Reese": "リサ",
   "Rover": "みしらぬネコ",


### PR DESCRIPTION
"Recycle box"  の日本語訳を修正しました。

”メッセージボトル” → "リサイクルボックス"

「ヨレヨレなシャツ」等が影響を受けます。

適当なタイミングでマージお願いします。
