### PR TITLE
コンプしていないのにコンプ率が100.0%表記になる不具合の修正

### DIFF
--- a/src/components/CollectedBar.vue
+++ b/src/components/CollectedBar.vue
@@ -4,7 +4,7 @@
       コンプ率
       {{
         props.totalValue !== 0
-          ? ((props.value / props.totalValue) * 100).toFixed(1)
+          ? (Math.floor(props.value / props.totalValue * 1000) / 1000 * 100).toFixed(1)
           : "0.0"
       }}%
     </div>

--- a/src/components/LoginCollectedBar.vue
+++ b/src/components/LoginCollectedBar.vue
@@ -8,7 +8,7 @@
       {{ props.totalValue }}
       ({{
         props.totalValue !== 0
-          ? ((props.value / props.totalValue) * 100).toFixed(1)
+          ? (Math.floor(props.value / props.totalValue * 1000) / 1000 * 100).toFixed(1)
           : "0.0"
       }}%)
     </div>


### PR DESCRIPTION
「ファッションすべて」「全体コンプ率」など、全体数が多い場合に
コンプしていないのに100.0%表記になる現象の修正PRです。

toFixedを掛ける前に小数点第2位以下を切り捨てるようにしました。