### PR TITLE
ファッションの取得方法フィルタに「リサイクル」を追加

### DIFF
--- a/src/components/FilterUI.vue
+++ b/src/components/FilterUI.vue
@@ -19,6 +19,7 @@
             <span v-else-if="filter.saleFilter === 'kicks'">シャンク</span>
             <span v-else-if="filter.saleFilter === 'labelle'">ことの</span>
             <span v-else-if="filter.saleFilter === 'daly'">日替わり</span>
+            <span v-else-if="filter.saleFilter === 'recycle'">リサイクル</span>
             <img src="../assets/arrow.svg" width="12" alt="" />
           </button>
         </div>
@@ -41,6 +42,9 @@
             </DropdownItem>
             <DropdownItem @click="onClickSaleFilter('daly')">
               <span class="tg">日替わり</span>
+            </DropdownItem>
+            <DropdownItem @click="onClickSaleFilter('recycle')">
+              <span class="tg">リサイクル</span>
             </DropdownItem>
           </template>
           <DropdownItem @click="onClickSaleFilter('diy')">

--- a/src/components/FilterUIShared.vue
+++ b/src/components/FilterUIShared.vue
@@ -19,6 +19,7 @@
             <span v-else-if="filter.saleFilter === 'kicks'">シャンク</span>
             <span v-else-if="filter.saleFilter === 'labelle'">ことの</span>
             <span v-else-if="filter.saleFilter === 'daly'">日替わり</span>
+            <span v-else-if="filter.saleFilter === 'recycle'">リサイクル</span>
             <img src="../assets/arrow.svg" width="12" alt="" />
           </button>
         </div>
@@ -41,6 +42,9 @@
             </DropdownItem>
             <DropdownItem @click="onClickSaleFilter('daly')">
               <span class="tg">日替わり</span>
+            </DropdownItem>
+            <DropdownItem @click="onClickSaleFilter('recycle')">
+              <span class="tg">リサイクル</span>
             </DropdownItem>
           </template>
           <DropdownItem @click="onClickSaleFilter('diy')">

--- a/src/utils/nav.js
+++ b/src/utils/nav.js
@@ -76,7 +76,12 @@ export function filterItems(args) {
       }
       // その他
       else if (filter.saleFilter === "other") {
-        if (item.diy || item.catalog === "For sale" || item.catalog === true)
+        if (
+          item.diy ||
+          item.catalog === "For sale" ||
+          item.catalog === true ||
+          (item.source && item.source.includes("Recycle box"))
+        )
           return false;
       }
       // エイブル
@@ -103,6 +108,12 @@ export function filterItems(args) {
           item.source &&
           !item.source.includes("Nook Shopping Daily Selection")
         ) {
+          return false;
+        }
+      }
+      // リサイクルボックス
+      else if (filter.saleFilter === "recycle") {
+        if (item.source && !item.source.includes("Recycle box")) {
           return false;
         }
       }


### PR DESCRIPTION
リサイクルボックスで入手するファッションアイテムは入手方法が特殊なためか
他のファッションアイテムとは別で交換するケースが多いようです。
カテゴリ追加の検討をお願いします。