### PR TITLE
クラウドとの定期同期が動作しない不具合の修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -200,7 +200,7 @@ export default {
           .then(function() {})
           .catch(function() {});
         this.$store.commit("updateCloudCollectedData", {
-          collected: this.localCollected,
+          collected: Object.assign({}, this.localCollected),
           updateIndex
         });
       }


### PR DESCRIPTION
クラウドにデータが保存されない不具合の修正PRです。

アイテムのチェック状態を変更後、3秒ごとに変更チェックでクラウドに保存されますが、
その際にcloudCollectedDataをlocalCollectedDataのシャロ―コピーで上書きしているため、
2回目以降は差分なしの扱いとなって同期されていません。

修正方法：
cloudCollectedDataをlocalCollectedDataのディープコピーで上書きするようにしました。


