### PR TITLE
シェア画面から通常画面に戻った時にアイテムが表示されない症状の修正

### DIFF
--- a/src/views/Collection.vue
+++ b/src/views/Collection.vue
@@ -278,6 +278,13 @@ export default {
         }
         this.changeNav(nav || "housewares-all");
       }
+
+      // Reset typeFilter
+      if (isAvailableFilter(this.activeNav, this.filter.typeFilter)) {
+        this.filter.typeFilter = "all";
+        this.$vlf.setItem("filter", this.filter);
+      }
+
       this.updateNavOrder();
     },
     onChangeItemCheck: function(itemName, itemCollectedData) {

--- a/src/views/Collection.vue
+++ b/src/views/Collection.vue
@@ -279,12 +279,7 @@ export default {
         this.changeNav(nav || "housewares-all");
       }
 
-      // Reset typeFilter
-      if (isAvailableFilter(this.activeNav, this.filter.typeFilter)) {
-        this.filter.typeFilter = "all";
-        this.$vlf.setItem("filter", this.filter);
-      }
-
+      this.resetTypeFilter();
       this.updateNavOrder();
     },
     onChangeItemCheck: function(itemName, itemCollectedData) {
@@ -351,12 +346,7 @@ export default {
       this.$copyText(names);
     },
     onChangeNav() {
-      // Reset typeFilter
-      if (isAvailableFilter(this.activeNav, this.filter.typeFilter)) {
-        this.filter.typeFilter = "all";
-        this.$vlf.setItem("filter", this.filter);
-      }
-
+      this.resetTypeFilter();
       this.updateShowItems();
     },
     onChangeView: function() {
@@ -484,6 +474,12 @@ export default {
             return 0;
           });
         }
+      }
+    },
+    resetTypeFilter() {
+      if (isAvailableFilter(this.activeNav, this.filter.typeFilter)) {
+        this.filter.typeFilter = "all";
+        this.$vlf.setItem("filter", this.filter);
       }
     }
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/75649436/105624657-de0cfb80-5e66-11eb-8df7-8a7524c0da64.png)

再現手順の例
1. ファッションカテゴリでフィルタを「エイブル」にする
2. シェア画面を開く（他人でも自分でも良い）
3. Drawerメニューから自分の家具カテゴリを開く
4. typeFilterがエイブルなので、ヒットするアイテムが見つからない

修正内容
filterをロードした直後にtypeFilterのチェック＆リセット処理を加えた
