### PR TITLE
島名の置換処理を追加

### DIFF
--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -314,8 +314,7 @@ export default {
         return 2;
       }
       return this.checks[index];
-    },
-    toDisplayItemName: toDisplayItemName
+    }
   }
 };
 </script>

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -105,11 +105,11 @@ export default {
       default: ""
     },
     item: Object,
+    itemName: String,
     filter: Object,
     isSearchMode: Boolean,
     renderStartDate: Number,
-    isStatic: Boolean,
-    islandName: String
+    isStatic: Boolean
   },
   directives: {
     "long-press": {
@@ -129,18 +129,6 @@ export default {
     };
   },
   computed: {
-    itemName() {
-      // 島名を置換
-      if (
-        this.islandName &&
-        (this.item.name === "(island name) Icons" ||
-          this.item.name === "(island name) Miles!")
-      ) {
-        return this.item.displayName.replace("○○", this.islandName);
-      } else {
-        return this.item.displayName;
-      }
-    },
     itemImage() {
       const item = this.item;
       if (item.variants) {

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -87,6 +87,7 @@
 import CheckForList from "./CheckForList";
 import CheckForTile from "./CheckForTile";
 import stampUrls from "../mixins/stampUrls";
+import { toDisplayItemName } from "../utils/nav";
 
 export default {
   name: "Item",
@@ -105,11 +106,11 @@ export default {
       default: ""
     },
     item: Object,
-    itemName: String,
     filter: Object,
     isSearchMode: Boolean,
     renderStartDate: Number,
-    isStatic: Boolean
+    isStatic: Boolean,
+    islandName: String
   },
   directives: {
     "long-press": {
@@ -129,6 +130,9 @@ export default {
     };
   },
   computed: {
+    itemName() {
+      return toDisplayItemName(this.item, this.islandName);
+    },
     itemImage() {
       const item = this.item;
       if (item.variants) {
@@ -310,7 +314,8 @@ export default {
         return 2;
       }
       return this.checks[index];
-    }
+    },
+    toDisplayItemName: toDisplayItemName
   }
 };
 </script>

--- a/src/utils/nav.js
+++ b/src/utils/nav.js
@@ -639,3 +639,16 @@ export function getNavText(nav) {
   });
   return navText;
 }
+
+export function toDisplayItemName(item, islandName) {
+  // 島名を置換
+  if (
+    islandName &&
+    (item.name === "(island name) Icons" ||
+      item.name === "(island name) Miles!")
+  ) {
+    return item.displayName.replace("○○", islandName);
+  } else {
+    return item.displayName;
+  }
+}

--- a/src/views/Collection.vue
+++ b/src/views/Collection.vue
@@ -190,7 +190,7 @@ export default {
       return this.$store.getters.islandName;
     },
     modalItemName() {
-      return this.toDisplayItemName(this.modalItem, this.islandName);
+      return toDisplayItemName(this.modalItem, this.islandName);
     },
     isVersion() {
       if (this.activeNav) {

--- a/src/views/Collection.vue
+++ b/src/views/Collection.vue
@@ -62,12 +62,12 @@
       <Item
         v-for="item in showItems"
         :item="item"
+        :itemName="toDisplayItemName(item, islandName)"
         :collected="getCollected(item)"
         :filter="filter"
         :isSearchMode="isSearchMode"
         :key="item.name + item.sourceSheet"
         :renderStartDate="renderStartDate"
-        :islandName="islandName"
         @change="onChangeItemCheck"
         @showModal="onShowModal"
       />
@@ -98,7 +98,9 @@
     </div>
     <Modal :show="isShowModal" @close="isShowModal = false">
       <template v-if="modalItem">
-        <template slot="header">{{ modalItem.displayName }}</template>
+        <template slot="header">{{
+          toDisplayItemName(modalItem, islandName)
+        }}</template>
         <div slot="body"><ItemModalContent :modalItem="modalItem" /></div>
       </template>
     </Modal>
@@ -113,7 +115,8 @@ import {
   filterItems,
   navs,
   totalLength,
-  collectedLength
+  collectedLength,
+  toDisplayItemName
 } from "../utils/nav.js";
 import { isAvailableFilter } from "../utils/filter";
 

--- a/src/views/Collection.vue
+++ b/src/views/Collection.vue
@@ -62,12 +62,12 @@
       <Item
         v-for="item in showItems"
         :item="item"
-        :itemName="toDisplayItemName(item, islandName)"
         :collected="getCollected(item)"
         :filter="filter"
         :isSearchMode="isSearchMode"
         :key="item.name + item.sourceSheet"
         :renderStartDate="renderStartDate"
+        :islandName="islandName"
         @change="onChangeItemCheck"
         @showModal="onShowModal"
       />
@@ -98,9 +98,7 @@
     </div>
     <Modal :show="isShowModal" @close="isShowModal = false">
       <template v-if="modalItem">
-        <template slot="header">{{
-          toDisplayItemName(modalItem, islandName)
-        }}</template>
+        <template slot="header">{{ modalItemName }}</template>
         <div slot="body"><ItemModalContent :modalItem="modalItem" /></div>
       </template>
     </Modal>
@@ -190,6 +188,9 @@ export default {
     },
     islandName() {
       return this.$store.getters.islandName;
+    },
+    modalItemName() {
+      return this.toDisplayItemName(this.modalItem, this.islandName);
     },
     isVersion() {
       if (this.activeNav) {

--- a/src/views/Share.vue
+++ b/src/views/Share.vue
@@ -69,12 +69,12 @@
         v-for="item in showItems"
         :key="item.name + item.sourceSheet"
         :item="item"
+        :itemName="toDisplayItemName(item, sharedIslandName)"
         :collected="getCollected(item)"
         :myCollected="getMyCollected(item)"
         :filter="filter"
         :isStatic="true"
         :renderStartDate="renderStartDate"
-        :islandName="sharedIslandName"
         @showModal="onShowModal"
       />
     </ul>
@@ -94,7 +94,9 @@
     </infinite-loading>
     <Modal :show="isShowModal" @close="isShowModal = false">
       <template v-if="modalItem">
-        <template slot="header">{{ modalItem.displayName }}</template>
+        <template slot="header">{{
+          toDisplayItemName(modalItem, sharedIslandName)
+        }}</template>
         <div slot="body"><ItemModalContent :modalItem="modalItem" /></div>
       </template>
     </Modal>
@@ -110,7 +112,8 @@ import {
   totalLength,
   collectedLength,
   getNavText,
-  navs
+  navs,
+  toDisplayItemName
 } from "../utils/nav.js";
 import { isAvailableFilter } from "../utils/filter";
 import { syncCollectedData } from "../utils/db.js";
@@ -370,7 +373,8 @@ export default {
 
       this.queueItems.splice(0, count);
       this.isLoadComplete = true;
-    }
+    },
+    toDisplayItemName: toDisplayItemName
   }
 };
 </script>

--- a/src/views/Share.vue
+++ b/src/views/Share.vue
@@ -374,8 +374,7 @@ export default {
 
       this.queueItems.splice(0, count);
       this.isLoadComplete = true;
-    },
-    toDisplayItemName: toDisplayItemName
+    }
   }
 };
 </script>

--- a/src/views/Share.vue
+++ b/src/views/Share.vue
@@ -217,7 +217,7 @@ export default {
       return this.$store.getters.isLogin;
     },
     modalItemName() {
-      return this.toDisplayItemName(this.modalItem, this.sharedIslandName);
+      return toDisplayItemName(this.modalItem, this.sharedIslandName);
     },
     navText() {
       return getNavText(this.nav);

--- a/src/views/Share.vue
+++ b/src/views/Share.vue
@@ -69,12 +69,12 @@
         v-for="item in showItems"
         :key="item.name + item.sourceSheet"
         :item="item"
-        :itemName="toDisplayItemName(item, sharedIslandName)"
         :collected="getCollected(item)"
         :myCollected="getMyCollected(item)"
         :filter="filter"
         :isStatic="true"
         :renderStartDate="renderStartDate"
+        :islandName="sharedIslandName"
         @showModal="onShowModal"
       />
     </ul>
@@ -94,9 +94,7 @@
     </infinite-loading>
     <Modal :show="isShowModal" @close="isShowModal = false">
       <template v-if="modalItem">
-        <template slot="header">{{
-          toDisplayItemName(modalItem, sharedIslandName)
-        }}</template>
+        <template slot="header">{{ modalItemName }}</template>
         <div slot="body"><ItemModalContent :modalItem="modalItem" /></div>
       </template>
     </Modal>
@@ -217,6 +215,9 @@ export default {
     },
     isLogin() {
       return this.$store.getters.isLogin;
+    },
+    modalItemName() {
+      return this.toDisplayItemName(this.modalItem, this.sharedIslandName);
     },
     navText() {
       return getNavText(this.nav);


### PR DESCRIPTION
アイテム詳細Modal画面に表示されるアイテム名に対して
島名の置換処理を加えました。
※nav.js に置換処理を移動して各コンポーネントから呼び出すように修正

修正後イメージ
![image](https://user-images.githubusercontent.com/75649436/105624804-d8fc7c00-5e67-11eb-87e2-3e88824b0320.png)
