### PR TITLE
PC（マウス操作）だとシェア画面でアイテム詳細Modal画面が表示されない現象の改善

### DIFF
--- a/src/components/CheckForTile.vue
+++ b/src/components/CheckForTile.vue
@@ -3,7 +3,6 @@
     type="button"
     class="t"
     :class="{ t1: props.value === 1, t2: props.value === 2 }"
-    :disabled="props.isStatic"
     v-on="listeners"
   >
     <div class="t-name">
@@ -42,7 +41,6 @@ export default {
     "variant",
     "variants",
     "isRecipe",
-    "isStatic",
     "isRemake"
   ]
 };

--- a/src/components/Item.vue
+++ b/src/components/Item.vue
@@ -1,7 +1,7 @@
 <template>
   <li :class="filter.viewMode === 'list' ? 'item' : 'tile'">
     <template v-if="filter.viewMode === 'list'">
-      <div v-long-press style="position: relative;">
+      <div class="item-img-block" v-long-press>
         <img v-lazy="itemImage" class="item-img" />
         <img
           class="item-img-remake"
@@ -58,7 +58,6 @@
             :value="getChecks(index)"
             :variant="item.variants[index]"
             :variants="item.variants"
-            :isStatic="isStatic"
             :isRemake="
               item.customize || item.bodyCustomize || item.patternCustomize
             "
@@ -73,7 +72,6 @@
             :image="itemImage"
             :value="getChecks(0)"
             :isRecipe="item.sourceSheet === 'Recipes'"
-            :isStatic="isStatic"
             :isRemake="
               item.customize || item.bodyCustomize || item.patternCustomize
             "
@@ -295,7 +293,7 @@ export default {
       return result;
     },
     onChangeCheck: function(index) {
-      if (!this.isShowDropdown) {
+      if (!this.isShowDropdown && !this.isStatic) {
         const currentValue = this.checks[index];
         const nextValue = currentValue === 2 ? 0 : currentValue + 1;
         this.checks[index] = nextValue;
@@ -303,7 +301,7 @@ export default {
       }
     },
     onClickAllCheck: function() {
-      if (!this.isShowDropdown) {
+      if (!this.isShowDropdown && !this.isStatic) {
         const nextState = this.allCheckState === 2 ? 0 : this.allCheckState + 1;
         let result = {};
         Object.keys(this.checks).forEach(key => {
@@ -341,6 +339,11 @@ export default {
   margin: 0;
   border-bottom: 1px solid #eee;
   user-select: none;
+}
+
+.item-img-block {
+  position: relative;
+  cursor: pointer;
 }
 
 .item-img {


### PR DESCRIPTION
＜修正方針＞
・buttonのdisabled設定を廃止
・アイテムタップ時に呼ばれるfunction内でisStaticの判定を追加

＜懸念点＞
シェア画面でもアイコンタップ時のアニメーションが有効になる点が許容されるか？
