### PR TITLE
アイテムの並び順（あいうえお順）を実機に合わせる修正

### DIFF
--- a/script/gen-json.js
+++ b/script/gen-json.js
@@ -449,8 +449,15 @@ function conversion(str) {
 allItems.sort(function(a, b) {
   const ca = conversion(a.displayName);
   const cb = conversion(b.displayName);
-  if (ca == cb) return 0;
-  if (ca > cb) {
+  if (ca == cb) {
+    if (a.displayName == b.displayName) {
+      return 0;
+    } else if (a.displayName > b.displayName) {
+      return 1;
+    } else {
+      return -1;
+    }
+  } else if (ca > cb) {
     return 1;
   } else {
     return -1;


### PR DESCRIPTION
アイテムの並び順（あいうえお順）の修正PRです。

- 影響①
  - 実機：きんのアイアンパーケットのゆか → ぎんの～
  - ガチコンプ：ぎんのアイアンパーケットのゆか → きんの～
- 影響②
  - 実機：ベール → ペール
  - ガチコンプ：ペール → ベール
 
①は同一カテゴリ内ですが、②はガチコンプで検索しないと気づけない（ユーザ影響が小さい）修正です。
