### PR TITLE
アイテムの名前順を実機（ItemStrSort.bcsv）に合わせる修正

### DIFF
--- a/script/gen-json.js
+++ b/script/gen-json.js
@@ -444,9 +444,7 @@ allItems = allItems.map(function(item) {
 // Sort items
 //
 
-sortItemsByName(allItems, item => {
-  return convertForSorting(item.yomigana || item.displayName);
-});
+sortItemsByName(allItems);
 
 //
 // Write file

--- a/src/utils/nav.js
+++ b/src/utils/nav.js
@@ -2,7 +2,7 @@ import itemsJson from "../assets/items.json";
 import navs from "./navs.json";
 import { typeFilter } from "./filter";
 
-const { convertForSorting, sortItemsByName } = require("../../script/sort.js");
+const { sortItemsByName } = require("../../script/sort.js");
 
 const kata2Hira = function(string) {
   return string.replace(/[\u30A1-\u30FA]/g, ch =>
@@ -23,14 +23,14 @@ const normalizeText = function(string) {
   return result;
 };
 
-// たぬきマイレージ：よみがなソート用の正規化
-const normalizeYomigana = function(item, islandName) {
-  let yomigana = item.yomigana || item.displayName;
-  // 島名を置換
+// たぬきマイレージ：名前順ソート時の島名置換
+const replaceIslandName = function(itemName, item, islandName) {
   if (islandName && hasIslandName(item)) {
-    yomigana = yomigana.replace("〓", islandName);
+    // 島名を置換
+    return itemName.replace("〓", islandName);
+  } else {
+    return itemName;
   }
-  return convertForSorting(yomigana);
 };
 
 // アイテムが「低木」であるかの判定
@@ -137,8 +137,8 @@ export function filterItems(args) {
     });
     // 島名を含む場合は名前順でソート
     if (islandName && items.some(item => hasIslandName(item))) {
-      sortItemsByName(items, item => {
-        return normalizeYomigana(item, islandName);
+      sortItemsByName(items, (itemName, item) => {
+        return replaceIslandName(itemName, item, islandName);
       });
     }
   } else {
@@ -633,8 +633,8 @@ export function filterItems(args) {
     //
 
     if (nav === "achievements" && filter.order === "name") {
-      sortItemsByName(items, item => {
-        return normalizeYomigana(item, islandName);
+      sortItemsByName(items, (itemName, item) => {
+        return replaceIslandName(itemName, item, islandName);
       });
     }
   }


### PR DESCRIPTION
ガチコンプのitem.jsonの並び順とマイニングデータのアイテム表示順定義データ（[ItemStrSort.bcsv](https://github.com/alexislours/crcpedia/blob/master/tables/ItemStrSort.md)）に従って
ソートした結果を比較して検知した差分の修正PRです。
※ItemStrSort.bcsvはアイテムではないリアクションとたぬきマイレージのソート定義は
含まれていないので、それら以外のアイテムでの比較になります。

参考：比較用に作ったスクリプト
https://github.com/FURI-J/acnh-gachi-complete/blob/develop/test/sort-test.js

▼ソート変化点１：実機（右側）に合わせて文字単位ではなく連続した数字の大小順（9⇒12⇒2021）で並ぶようにしました
![image](https://user-images.githubusercontent.com/75649436/108503274-6e6c1e00-72f7-11eb-8f9f-2c66f93f8744.png)

▼ソート変化点２：実機（右側）に合わせて中黒（・）などの全角記号を削除してソートするようにしました
![image](https://user-images.githubusercontent.com/75649436/108503480-cb67d400-72f7-11eb-8681-128d3a6ea305.png)

▼ソート変化点３：実機（右側）に合わせてェ⇒エの変換を加えました（同様にァ⇒アなども追加）
![image](https://user-images.githubusercontent.com/75649436/108503565-efc3b080-72f7-11eb-9a5c-406b4138f4bb.png)

▼ソート変化点４：実機（右側）に合わせて文字列の途中に数値が来ても先頭に来るようにしました
![image](https://user-images.githubusercontent.com/75649436/108503696-2994b700-72f8-11eb-91a8-ac3d3e3b9f28.png)

▼ソート以外の修正
名前順ソートに使う対象の判定（item.yomigana || item.displayName）が
script/gen-json.js と src/utils/nav.js に分散していたのを
共通の script/sort.js に集約しました。
