### PR TITLE
Androidでアイテム詳細ダイアログ表示時に画像メニューが開かないように対応

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -146,4 +146,9 @@ export default {
 .modal-leave-active .modal-container {
   transform: scale(1.1);
 }
+
+.modal-enter .modal-container,
+.modal-enter-active .modal-container {
+  pointer-events: none;
+}
 </style>


### PR DESCRIPTION
アイテム詳細ダイアログ表示時にロングタップした位置とアイテム画像が被ると
画像ロングタップ時のメニューが同時に出る現象の修正PRです。
Android10のChromeで本現象が出ることを確認しています。
※iOSのSafariとChromeではこの現象が出ないようです。

再現動画
https://twitter.com/dreamtowerx/status/1362981516133851137?s=20

Vueトランジションのv-enterとv-enter-activeでのみメニュー表示を無効化、
ダイアログ表示後は修正前と同じく画像ロングタップでメニュー表示されます。