### PR TITLE
πパイの並び順を実機に合わせる対応

### DIFF
--- a/script/gen-json.js
+++ b/script/gen-json.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const { array_move, numberWithCommas } = require("./utils.js");
-const { convertForSorting, sortItemsByName } = require("./sort.js");
+const { sortItemsByName } = require("./sort.js");
 
 //
 // Load Json


### PR DESCRIPTION
#59 のPRです。

SJISコード順でのソートだと全角英数や一部記号の並び順が期待通りにならなかったため、
以下の方針で修正しました。

1. sort.jsの全角記号削除（symbol_conv）で先頭文字を除外（πを残す）
2. ソート時に全角記号は最後尾へ来るように考慮

※なんとなく姑息な手段のような感じで、今回の対応だけでは不十分な気がしますが、
Ver1.9.0以降もItemStrSort.bcsvと比較させていただきますので
差分が出たらその都度対応させてください。