### PR TITLE
カタログスキャナーから「いしのみずうけ～さくら～」「いしのみずうけ～もみじ～」がインポートできない不具合の修正

### DIFF
--- a/src/components/LoginCatalogScanner.vue
+++ b/src/components/LoginCatalogScanner.vue
@@ -114,9 +114,11 @@ export default {
           const failedNames = [];
 
           for (const name of names) {
+            const catalogName = zen_han_conv(name);
             const item = itemsJson.find(item => {
               const isMatchName =
-                zen_han_conv(item.displayName) === name || item.name === name;
+                zen_han_conv(item.displayName) === catalogName ||
+                item.name === name;
               if (isRecipe) {
                 return isMatchName && item.sourceSheet === "Recipes";
               } else {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -14,6 +14,6 @@ export function zen_han_conv(str) {
   });
   str = str.replace(/（/g, "(");
   str = str.replace(/）/g, ")");
-  str = str.replace(/~/g, "～");
+  str = str.replace(/～/g, "~");
   return str;
 }


### PR DESCRIPTION
カタログスキャナーを試したところ、
「いしのみずうけ～さくら～」「いしのみずうけ～もみじ～」でアイテム名不一致メッセージが出ました。

チルダの全半角変換が逆のようですのでご確認お願いします。