### PR TITLE
アイテム名ソート時の大文字・小文字の区別を廃止

### DIFF
--- a/script/sort.js
+++ b/script/sort.js
@@ -14,7 +14,7 @@ function zen_han_conv(str) {
     const chr = match.charCodeAt(0) + 0xfee0;
     return String.fromCharCode(chr);
   });
-  return str;
+  return str.toUpperCase();
 }
 
 function daku_conv(str) {
@@ -77,7 +77,7 @@ function symbol_conv(str) {
 function convertForSorting(str) {
   // ひらがな⇒カタカナ
   str = kana_conv(str);
-  // 数字⇒半角、アルファベット⇒全角
+  // 数字⇒半角、アルファベット⇒全角大文字
   str = zen_han_conv(str);
   // 長音変換（ポスター⇒ポスタア）
   str = choon_conv(str);


### PR DESCRIPTION
あいうえお順の並び順を実機に合わせる修正のPRです。

ガチコンプ：1UPキノコ→1stアニバーサリーケーキ
実機：1stアニバーサリーケーキ→1UPキノコ

※これ以外は実機（ItemStrSort.bcsv）との差分はありませんでした。