### PR TITLE
イースター家具の入手時期の修正

### DIFF
--- a/data/translation-custom/seasonEvent.json
+++ b/data/translation-custom/seasonEvent.json
@@ -8,7 +8,7 @@
   "Birthday": "プレイヤーの誕生日",
   "Bug-Off": "6, 7, 8, 9月の第4土曜日（虫取り大会）",
   "Bunny Day": "4/4（イースター当日）",
-  "Bunny Day (ready days); Bunny Day": "3/28〜4/3（イースター準備期間と当日）",
+  "Bunny Day (ready days); Bunny Day": "3/28〜4/4（イースター準備期間と当日）",
   "Cancer": "6/22〜7/22（かに座の時期）",
   "Capricorn": "12/22〜1/19（やぎ座の時期）",
   "Countdown": "12/31（カウントダウン）",


### PR DESCRIPTION
当日（4/4）を期間に含める修正です。ご確認お願いします。
