### PR TITLE
アイテム名変更の互換性対応

### DIFF
--- a/script/gen-json.js
+++ b/script/gen-json.js
@@ -44,6 +44,8 @@ const customTranslations = [
 
 const customAchievementData = require("../data/item-data-custom/achievements.json");
 
+const oldItems = require("../src/assets/items.json");
+
 //
 // items データ生成
 //
@@ -460,6 +462,23 @@ allItems = allItems.map(function(item) {
 //
 
 sortItemsByName(allItems);
+
+//
+// Rename check
+//
+
+const renamedItems = oldItems.filter((item) => {
+  const name = item.name;
+  const find = allItems.find((newItem) => newItem.name === name);
+  const isRenamed = find ? false : true;
+
+  return isRenamed;
+});
+
+if (renamedItems.length > 0) {
+  console.log("Renamed Items:");
+  console.log(renamedItems);
+}
 
 //
 // Write file

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,10 @@
 import Vue from "vue";
 import Vuex from "vuex";
 import localforage from "localforage";
+import {
+  makeCompatibleCollection,
+  makeCompatibleWishlist,
+} from "../utils/utils.js";
 
 Vue.use(Vuex);
 
@@ -43,15 +47,20 @@ export default new Vuex.Store({
       state.isLogin = nextState;
     },
     initLocalCollectedData(state, payload) {
+      payload.collected = makeCompatibleCollection(payload.collected);
       state.localCollectedData = Object.assign({}, payload.collected);
       state.localUpdateIndex = payload.updateIndex;
     },
     initCloudCollectedData(state, payload) {
+      payload.collected = makeCompatibleCollection(payload.collected);
       state.cloudCollectedData = payload.collected;
       state.cloudUpdateIndex = payload.updateIndex;
     },
     initWishlist(state, array) {
-      if (array) state.wishlist = array;
+      if (array) {
+        array = makeCompatibleWishlist(array);
+        state.wishlist = array;
+      }
     },
     updateLocalCollectedDataByItem(state, payload) {
       if (payload.itemCollectedData === "") {
@@ -105,6 +114,7 @@ export default new Vuex.Store({
       localforage.setItem("islandName", name);
     },
     updateSharedCollected(state, data) {
+      data = makeCompatibleCollection(data);
       state.sharedCollected = data;
     },
     updateSharedUserName(state, data) {
@@ -127,7 +137,10 @@ export default new Vuex.Store({
       if (array) state.cloudWishlist = array;
     },
     updateSharedWishlist(state, array) {
-      if (array) state.sharedWishlist = array;
+      if (array) {
+        array = makeCompatibleWishlist(array);
+        state.sharedWishlist = array;
+      }
     },
     isShowDropdown(state, isShow) {
       state.isShowDropdown = isShow;

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -57,3 +57,49 @@ export function isInWishlist(item, index) {
 
   return wishlist.includes(entryId);
 }
+
+const RENAME_MAP = {
+  "paper bag": "paper-bag hood",
+  "olive desert-tile wall": "olive Moroccan wall",
+  "olive desert-tile flooring": "olive Moroccan flooring",
+  "blue desert-tile wall": "blue Moroccan wall",
+  "blue desert-tile flooring": "blue Moroccan flooring",
+  "beige desert-tile wall": "beige Moroccan wall",
+  "beige desert-tile flooring": "beige Moroccan flooring",
+  "teacup ride": "plaza teacup ride",
+  "purple desert-tile wall": "purple Moroccan wall",
+  "purple desert-tile flooring": "purple Moroccan flooring",
+  "Green Nook Inc. aloha shirt": "green Nook Inc. aloha shirt",
+  "Coral Nook Inc. aloha shirt": "coral Nook Inc. aloha shirt",
+  "Shrubbery Hububbery": "Shrubbery Hubbubbery",
+  "Pit-y Party!": "Pit-y Party",
+};
+
+export function makeCompatibleCollection(collected) {
+  const newCollected = Object.assign({}, collected);
+
+  Object.keys(RENAME_MAP).forEach((oldName) => {
+    const newName = RENAME_MAP[oldName];
+    if (newCollected[oldName]) {
+      if (!newCollected[newName]) {
+        newCollected[newName] = newCollected[oldName];
+      }
+      delete newCollected[oldName];
+    }
+  });
+
+  return newCollected;
+}
+
+export function makeCompatibleWishlist(wishlist) {
+  const newWishlist = wishlist.map((wishdata) => {
+    const wishdataArray = wishdata.split("_");
+    const name = wishdataArray[0];
+    const variant = wishdataArray[1];
+    const newName = RENAME_MAP[name];
+
+    return newName ? `${newName}_${variant}` : wishdata;
+  });
+
+  return newWishlist;
+}


### PR DESCRIPTION
以下を追加

* コレクションデータとウィッシュリストのリネームを行う処理
* npm run gen 時にアイテム名変更がある場合にメッセージを表示

Fixes #106