### PR TITLE
アイテムモーダルにDIY素材の表示を追加

### DIFF
--- a/src/components/ItemModalContent.vue
+++ b/src/components/ItemModalContent.vue
@@ -217,6 +217,14 @@
       <div class="info-label info-4">タヌポイント</div>
       <div class="info-text">{{ modalItem.exchangePrice }}</div>
     </div>
+    <div class="info" v-if="modalItem.materialsJa">
+      <div class="info-label info-7">素材</div>
+      <div class="info-materials">
+        <span v-for="(value, name) in modalItem.materialsJa" :key="name">
+          {{ name }} x {{ value }}<br />
+        </span>
+      </div>
+    </div>
     <div class="info" v-if="modalItem.versionAdded">
       <div class="info-label info-6">追加されたバージョン</div>
       <div class="info-text">{{ modalItem.versionAdded }}</div>
@@ -361,10 +369,18 @@ export default {
   background-color: #888;
 }
 
+.info-7 {
+  background-color: #888;
+}
+
 .info-text {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  padding: 0.2rem 0.4rem;
+}
+
+.info-materials {
   padding: 0.2rem 0.4rem;
 }
 


### PR DESCRIPTION
DIYアイテムのモーダルに必要素材を表示するPRです。
![image](https://user-images.githubusercontent.com/75649436/142216260-13b4c4be-9248-4ad4-b90e-1b061a7e5ce0.png)

元データにはレシピ側にしか素材情報はありませんが、
利便性を考えてレシピと作成後アイテムの両方に表示するようにしています。

もし採用いただけるようでしたら、デザインの調整（「素材」項目の背景色など）はお願いしたいです。

残課題：素材のアイコン（アイテム画像）を表示する
→時間がかかりそうだったので、必要でしたら週末対応します。