### PR TITLE
ははシリーズのメニュー不具合修正

### DIFF
--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -8,7 +8,7 @@
           class="nav-item"
           :class="[
             {
-              active: active && active.includes(nav.id),
+              active: active && active.startsWith(nav.id),
               separator: nav.separator,
             },
             nav.class,
@@ -150,7 +150,7 @@ export default {
     background-color: #ab47bc;
   }
 
-svg {
+  svg {
     color: #ab47bc;
   }
 }
@@ -160,7 +160,7 @@ svg {
     background-color: #ff617c;
   }
 
-svg {
+  svg {
     color: #ff617c;
   }
 }

--- a/src/components/SubNav.vue
+++ b/src/components/SubNav.vue
@@ -43,7 +43,7 @@ export default {
     navText() {
       if (this.active) {
         const activeNavObj = this.navs.filter((nav) => {
-          return this.active.includes(nav.id);
+          return this.active.startsWith(nav.id);
         });
         if (activeNavObj.length > 0) {
           return activeNavObj[0].text;
@@ -54,7 +54,7 @@ export default {
     subnavs: function () {
       if (this.active) {
         const activeNavObj = this.navs.filter((nav) => {
-          return this.active.includes(nav.id);
+          return this.active.startsWith(nav.id);
         });
         if (activeNavObj.length > 0) {
           return activeNavObj[0].subnavs;


### PR DESCRIPTION
ははシリーズで「その他」のメニューが表示される不具合の修正PRです。

↓「その他」のメニュー表示
![image](https://user-images.githubusercontent.com/75649436/142383032-13de4b96-c142-4c9a-8aec-963b464e02bd.png)

↓「その他」と「季節/イベント」の2つがアクティブになる
![image](https://user-images.githubusercontent.com/75649436/142383086-ddbbbfd6-aad4-4dfb-94eb-f6954bdfd2bf.png)

＜原因＞
その他のナビID（other）がははシリーズのナビID（season-mother）に部分一致しているため。

＜修正方針＞
IDの変更はシェアURL等に影響するので、部分一致ではなく前方一致とした。