### PR TITLE
コンプ率計算の改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
         "sass": "^1.26.5",
         "sass-loader": "^8.0.2",
         "vue-analytics": "^5.22.1",
-        "vue-template-compiler": "^2.6.11"
+        "vue-template-compiler": "^2.6.11",
+        "worker-loader": "^3.0.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -16297,6 +16298,58 @@
         "errno": "~0.1.7"
       }
     },
+    "node_modules/worker-loader": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/worker-loader/node_modules/loader-utils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/worker-loader/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -29647,6 +29700,40 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-loader": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+      "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",
     "vue-analytics": "^5.22.1",
-    "vue-template-compiler": "^2.6.11"
+    "vue-template-compiler": "^2.6.11",
+    "worker-loader": "^3.0.8"
   }
 }

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -37,7 +37,7 @@
         </Button>
       </div>
 
-      <LoginCollected @change="setUpdateCollectedId" />
+      <LoginCollected ref="loginCollected" />
 
       <LoginSettings :settings="settings" @change="changeSettings" />
 
@@ -85,11 +85,6 @@ const db = firebase.firestore();
 
 export default {
   name: "Login",
-  data() {
-    return {
-      updateCollectedId: 0,
-    };
-  },
   components: {
     CloseButton,
     Button,
@@ -140,10 +135,8 @@ export default {
         });
     },
     close() {
-      if (this.updateCollectedId) {
-        // コンプ率更新AnimationFrameをキャンセルする
-        cancelAnimationFrame(this.updateCollectedId);
-      }
+      // コンプ率更新を中断
+      this.$refs.loginCollected.abortUpdateCollected();
       this.$emit("close");
     },
     saveName(newName) {
@@ -160,9 +153,6 @@ export default {
     },
     changeSettings(newValue) {
       this.$store.commit("changeSettings", newValue);
-    },
-    setUpdateCollectedId(id) {
-      this.updateCollectedId = id;
     },
   },
 };

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -37,7 +37,7 @@
         </Button>
       </div>
 
-      <LoginCollected />
+      <LoginCollected @change="setUpdateCollectedId" />
 
       <LoginSettings :settings="settings" @change="changeSettings" />
 
@@ -85,6 +85,11 @@ const db = firebase.firestore();
 
 export default {
   name: "Login",
+  data() {
+    return {
+      updateCollectedId: 0,
+    };
+  },
   components: {
     CloseButton,
     Button,
@@ -135,6 +140,10 @@ export default {
         });
     },
     close() {
+      if (this.updateCollectedId) {
+        // コンプ率更新AnimationFrameをキャンセルする
+        cancelAnimationFrame(this.updateCollectedId);
+      }
       this.$emit("close");
     },
     saveName(newName) {
@@ -151,6 +160,9 @@ export default {
     },
     changeSettings(newValue) {
       this.$store.commit("changeSettings", newValue);
+    },
+    setUpdateCollectedId(id) {
+      this.updateCollectedId = id;
     },
   },
 };

--- a/src/components/LoginCollected.vue
+++ b/src/components/LoginCollected.vue
@@ -89,7 +89,7 @@ export default {
       };
 
       // CollectedLength更新完了までの目安時間（ミリ秒）
-      const MSEC = 500;
+      const MSEC = 800;
       // LoginCollectedBarに渡すCollectedLengthの小数点以下精度
       const PREC = 1000;
 
@@ -142,11 +142,9 @@ export default {
             }
           }
         );
-        if (update) {
+        if (this.isGetting && update) {
           fps = 1000 / ((performance.now() - start) / ++frame);
-          this.$emit("change", requestAnimationFrame(updateCollected));
-        } else {
-          this.$emit("change", 0);
+          requestAnimationFrame(updateCollected);
         }
       };
 
@@ -195,6 +193,12 @@ export default {
         }
       });
       return result;
+    },
+    abortUpdateCollected() {
+      this.isGetting = false;
+      this.$worker.postMessage({
+        abort: true,
+      });
     },
   },
 };

--- a/src/components/LoginCollected.vue
+++ b/src/components/LoginCollected.vue
@@ -143,7 +143,9 @@ export default {
         );
         if (update) {
           fps = 1000 / ((performance.now() - start) / ++frame);
-          requestAnimationFrame(updateCollected);
+          this.$emit("change", requestAnimationFrame(updateCollected));
+        } else {
+          this.$emit("change", 0);
         }
       };
 

--- a/src/components/LoginCollected.vue
+++ b/src/components/LoginCollected.vue
@@ -39,12 +39,6 @@
 </template>
 
 <script>
-import {
-  totalLength,
-  collectedLength,
-  allTotalLength,
-  allCollectedLength,
-} from "../utils/filterItems";
 import { navs } from "../utils/navs";
 import Card from "./Card";
 import LoginCollectedBar from "./LoginCollectedBar";
@@ -57,8 +51,8 @@ export default {
       isLoadComplete: null,
       totalLengths: null,
       collectedLengths: null,
-      allTotalLength: null,
-      allCollectedLength: null,
+      allTotalLength: undefined,
+      allCollectedLength: undefined,
     };
   },
   components: {
@@ -69,6 +63,9 @@ export default {
   computed: {
     collected() {
       return this.$store.getters.localCollectedData;
+    },
+    isFullMode() {
+      return this.$store.getters.settings.isFullMode;
     },
     partnerlist() {
       return this.$store.getters.partnerlist;
@@ -82,41 +79,112 @@ export default {
   methods: {
     startGetLength() {
       this.isGetting = true;
-      setTimeout(() => {
-        this.totalLengths = this.getLengths();
-        this.collectedLengths = this.getLengths(true);
-        this.allTotalLength = allTotalLength();
-        this.allCollectedLength = allCollectedLength(
-          this.collected,
-          this.partnerlist
+      this.totalLengths = this.initLengths();
+      this.collectedLengths = Object.assign({}, this.totalLengths);
+
+      const workerResult = {
+        collectedLengths: [],
+        complete: false,
+      };
+
+      // CollectedLength更新完了までの目安時間（ミリ秒）
+      const MSEC = 500;
+      // LoginCollectedBarに渡すCollectedLengthの小数点以下精度
+      const PREC = 1000;
+
+      let start = 0;
+      let frame = 0;
+      let fps = 60;
+      let currentCollectedLengths = {};
+      const updateCollected = () => {
+        let update = !workerResult.complete;
+        if (workerResult.allCollectedLength >= 0) {
+          const newCollectedLength = Math.min(
+            Math.ceil(
+              (this.allCollectedLength +
+                workerResult.allCollectedLength / fps / (MSEC / 1000)) *
+                PREC
+            ) / PREC,
+            workerResult.allCollectedLength
+          );
+          if (newCollectedLength > this.allCollectedLength) {
+            this.allCollectedLength = newCollectedLength;
+            update = true;
+          } else {
+            delete workerResult["allCollectedLength"];
+          }
+        }
+        Object.entries(workerResult.collectedLengths).forEach(
+          ([id, length]) => {
+            const newCollectedLength = Math.min(
+              Math.ceil(
+                (currentCollectedLengths[id] + length / fps / (MSEC / 1000)) *
+                  PREC
+              ) / PREC,
+              length
+            );
+            if (newCollectedLength > currentCollectedLengths[id]) {
+              if (
+                (newCollectedLength - this.collectedLengths[id]) / length >=
+                0.02
+              ) {
+                // 更新頻度を下げるため、2%以上の変動がある場合のみ更新
+                this.collectedLengths[id] = newCollectedLength;
+              }
+              currentCollectedLengths[id] = newCollectedLength;
+              update = true;
+            } else {
+              if (newCollectedLength > this.collectedLengths[id]) {
+                this.collectedLengths[id] = newCollectedLength;
+              }
+              delete workerResult.collectedLengths[id];
+            }
+          }
         );
-        this.isLoadComplete = true;
-        this.isGetting = false;
-      }, 0);
+        if (update) {
+          fps = 1000 / ((performance.now() - start) / ++frame);
+          requestAnimationFrame(updateCollected);
+        }
+      };
+
+      /* TotalLengthとCollectedLengthはUIスレッドの負荷を下げるために別スレッド（WebWorker）で計算する */
+      this.$worker.onmessage = (e) => {
+        const { data } = e;
+        if (data.allTotalLength !== undefined) {
+          this.isLoadComplete = true;
+          this.allTotalLength = data.allTotalLength;
+        } else if (data.allCollectedLength !== undefined) {
+          this.allCollectedLength = 0;
+          workerResult.allCollectedLength = data.allCollectedLength;
+          start = performance.now();
+          requestAnimationFrame(updateCollected);
+        } else if (data.navsLengths) {
+          Object.entries(data.navsLengths).forEach(([id, lengths]) => {
+            this.totalLengths[id] = lengths[0];
+            this.collectedLengths[id] = 0;
+            currentCollectedLengths[id] = 0;
+            workerResult.collectedLengths[id] = lengths[1];
+          });
+        } else if (data.complete) {
+          workerResult.complete = true;
+        }
+      };
+      this.$worker.postMessage({
+        collected: this.collected,
+        isFullMode: this.isFullMode,
+        partnerlist: this.partnerlist,
+      });
     },
-    getLengths(isCollected) {
+    initLengths() {
       const result = {};
       this.navs.forEach((nav) => {
         const subnavs = nav.subnavs;
-        const collected = this.collected;
         if (subnavs) {
           subnavs.forEach((subnav) => {
-            result[subnav.id] = isCollected
-              ? collectedLength({
-                  nav: subnav.id,
-                  collected,
-                  partnerlist: this.partnerlist,
-                })
-              : totalLength({ nav: subnav.id, partnerlist: this.partnerlist });
+            result[subnav.id] = undefined;
           });
         } else {
-          result[nav.id] = isCollected
-            ? collectedLength({
-                nav: nav.id,
-                collected,
-                partnerlist: this.partnerlist,
-              })
-            : totalLength({ nav: nav.id, partnerlist: this.partnerlist });
+          result[nav.id] = undefined;
         }
       });
       return result;

--- a/src/components/LoginCollectedBar.vue
+++ b/src/components/LoginCollectedBar.vue
@@ -4,8 +4,8 @@
       <div class="left">
         {{ props.text }}
       </div>
-      <div class="right">
-        {{ props.value }} /
+      <div class="right" v-if="props.totalValue > 0">
+        {{ Math.round(props.value) }} /
         {{ props.totalValue }}
         ({{ $options.percentage(props.value, props.totalValue) }})
       </div>
@@ -32,11 +32,17 @@
 import { percentage } from "../utils/utils";
 
 export default {
-  prop: {
-    text: "",
-    value: 0,
-    totalValue: 0,
-    isAll: false,
+  props: {
+    text: String,
+    value: {
+      type: Number,
+      default: 0,
+    },
+    totalValue: {
+      type: Number,
+      default: 0,
+    },
+    isAll: Boolean,
   },
   percentage,
   isComplete(value, totalValue) {

--- a/src/components/ToolbarShare.vue
+++ b/src/components/ToolbarShare.vue
@@ -109,6 +109,7 @@ export default {
         nav: this.activeNav,
         typeFilter: "all",
         isForceLess: true,
+        isFullMode: this.isFullMode,
         partnerlist: this.partnerlist,
       });
       const _collectedLength = collectedLength({
@@ -116,6 +117,7 @@ export default {
         nav: this.activeNav,
         typeFilter: "all",
         isForceLess: true,
+        isFullMode: this.isFullMode,
         partnerlist: this.partnerlist,
       });
       const _providableLength = providableLength({
@@ -123,6 +125,7 @@ export default {
         nav: this.activeNav,
         typeFilter: "all",
         isForceLess: true,
+        isFullMode: this.isFullMode,
         partnerlist: this.partnerlist,
       });
       this.tweetString = `あつ森ガチコンプ『${this.navText}』チェッカー`;

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import Vue from "vue";
 import Vlf from "vlf";
 import localforage from "localforage";
-import { extendPrototype } from 'localforage-removeitems';
+import { extendPrototype } from "localforage-removeitems";
 extendPrototype(localforage);
 import VueLazyload from "vue-lazyload";
 import VueAnalytics from "vue-analytics";
@@ -17,6 +17,9 @@ import router from "./router";
 import store from "./store";
 import Auth from "./utils/auth";
 Auth.init();
+
+import ItemLengthWorker from "worker-loader!./workers/item_length_worker";
+Vue.prototype.$worker = new ItemLengthWorker();
 
 Vue.config.productionTip = false;
 Vue.use(Vlf, localforage);

--- a/src/utils/filterItems.js
+++ b/src/utils/filterItems.js
@@ -5,7 +5,6 @@ import hhpRequestJson from "../assets/hhp-request.json";
 import { navsFlat } from "./navs";
 import { typeFilter } from "./filter";
 import { hasIslandName, toDisplayItemName } from "./utils";
-import store from "../store";
 
 let fullItemsJson = cloneDeep(originalItemsJson);
 let lessItemsJson = cloneDeep(originalItemsJson);
@@ -110,11 +109,10 @@ export function filterItems(args) {
     updateMatchedVariants = false,
     wishlist = [],
     isForceLess = false,
+    isFullMode = false,
+    isShareView = false,
     partnerlist = [],
   } = args;
-
-  let isFullMode = store.getters.settings.isFullMode;
-  let isShareView = store.getters.isShareView;
 
   let items =
     !isForceLess && !isShareView && isFullMode ? fullItemsJson : lessItemsJson;
@@ -466,7 +464,15 @@ export function filterPartnerCandidates(selfItem, partnerlist, searchText) {
 }
 
 export function totalLength(args) {
-  const { nav, typeFilter, version, isForceLess, partnerlist } = args;
+  const {
+    nav,
+    typeFilter,
+    version,
+    isForceLess,
+    isFullMode,
+    isShareView,
+    partnerlist,
+  } = args;
   const items = filterItems({
     nav,
     filter: {
@@ -474,16 +480,16 @@ export function totalLength(args) {
       version: version,
     },
     isForceLess,
+    isFullMode,
+    isShareView,
     partnerlist,
   });
 
   return calcTotalLength(items);
 }
 
-export function allTotalLength() {
-  let isFullMode = store.getters.settings.isFullMode;
-  let isShareView = store.getters.isShareView;
-  let partnerlist = store.getters.partnerlist;
+export function allTotalLength(args) {
+  const { isFullMode, isShareView, partnerlist } = args;
 
   let items = isShareView || !isFullMode ? lessItemsJson : fullItemsJson;
   items = items.filter(filterOtherItem);
@@ -493,8 +499,16 @@ export function allTotalLength() {
 }
 
 export function collectedLength(args) {
-  const { collected, nav, typeFilter, version, isForceLess, partnerlist } =
-    args;
+  const {
+    collected,
+    nav,
+    typeFilter,
+    version,
+    isForceLess,
+    isFullMode,
+    isShareView,
+    partnerlist,
+  } = args;
   const collectedItems = filterItems({
     collected,
     nav,
@@ -504,17 +518,22 @@ export function collectedLength(args) {
       version: version,
     },
     isForceLess,
-    partnerlist: partnerlist,
+    isFullMode,
+    isShareView,
+    partnerlist,
   });
 
   return calcCollectedLength(collected, collectedItems);
 }
 
-export function allCollectedLength(collected, partnerlist) {
+export function allCollectedLength(args) {
+  const { collected, isFullMode, isShareView, partnerlist } = args;
   let collectedItems = filterItems({
     collected,
     filter: { collectedFilter: "3" },
-    partnerlist: partnerlist,
+    isFullMode,
+    isShareView,
+    partnerlist,
   });
   collectedItems = collectedItems.filter(filterOtherItem);
 
@@ -522,7 +541,15 @@ export function allCollectedLength(collected, partnerlist) {
 }
 
 export function providableLength(args) {
-  const { collected, nav, typeFilter, isForceLess, partnerlist } = args;
+  const {
+    collected,
+    nav,
+    typeFilter,
+    isForceLess,
+    isFullMode,
+    isShareView,
+    partnerlist,
+  } = args;
   const collectedItems = filterItems({
     collected,
     nav,
@@ -531,6 +558,8 @@ export function providableLength(args) {
       collectedFilter: "2",
     },
     isForceLess,
+    isFullMode,
+    isShareView,
     partnerlist,
   });
 

--- a/src/views/Collection.vue
+++ b/src/views/Collection.vue
@@ -299,6 +299,7 @@ export default {
           nav: this.activeNav,
           typeFilter: this.filter.typeFilter,
           version: this.filter.version,
+          isFullMode: this.isFullMode,
           partnerlist: this.partnerlist,
         });
       }
@@ -312,6 +313,7 @@ export default {
           nav: this.activeNav,
           typeFilter: this.filter.typeFilter,
           version: this.filter.version,
+          isFullMode: this.isFullMode,
           partnerlist: this.partnerlist,
         });
       }
@@ -598,6 +600,7 @@ export default {
         islandName: this.islandName,
         updateMatchedVariants: true,
         wishlist: this.wishlist,
+        isFullMode: this.isFullMode,
         partnerlist: this.partnerlist,
       });
 

--- a/src/views/Share.vue
+++ b/src/views/Share.vue
@@ -249,6 +249,7 @@ export default {
         nav: this.nav,
         typeFilter: this.filter.typeFilter,
         version: this.filter.version,
+        isShareView: true,
         partnerlist: this.sharedPartnerlist,
       });
     },
@@ -258,6 +259,7 @@ export default {
         nav: this.nav,
         typeFilter: this.filter.typeFilter,
         version: this.filter.version,
+        isShareView: true,
         partnerlist: this.sharedPartnerlist,
       });
     },
@@ -410,6 +412,7 @@ export default {
         islandName: this.sharedIslandName,
         updateMatchedVariants: true,
         wishlist: this.sharedWishlist,
+        isShareView: true,
         partnerlist: this.sharedPartnerlist,
       });
 

--- a/src/workers/item_length_worker.js
+++ b/src/workers/item_length_worker.js
@@ -6,8 +6,18 @@ import {
 } from "../utils/filterItems";
 import { navs } from "../utils/navs";
 
+// 中断指示フラグ
+let abort = false;
+
 addEventListener("message", (e) => {
   const { data } = e;
+
+  if (data.abort) {
+    abort = true;
+    return;
+  } else {
+    abort = false;
+  }
 
   /* 全体のTotalLength */
   postMessage({
@@ -18,6 +28,9 @@ addEventListener("message", (e) => {
     }),
   });
 
+  /* 中断指示チェック */
+  if (abort) return;
+
   /* 全体のCollectedLength */
   postMessage({
     requestId: data.requestId,
@@ -27,6 +40,9 @@ addEventListener("message", (e) => {
       partnerlist: data.partnerlist,
     }),
   });
+
+  /* 中断指示チェック */
+  if (abort) return;
 
   /* nav別のTotalLengthとCollectedLength */
   let navsLengths = {};
@@ -52,6 +68,8 @@ addEventListener("message", (e) => {
             }),
           ];
         });
+        /* 中断指示チェック */
+        if (abort) return;
       } else {
         navsLengths[nav.id] = [
           totalLength({
@@ -67,6 +85,8 @@ addEventListener("message", (e) => {
           }),
         ];
       }
+      /* 中断指示チェック */
+      if (abort) return;
       /* nav単位で送信すると特にAndroidでCollectedLengthの更新遅延が発生する。そのため、ある程度まとめて送信する。 */
       if (Object.keys(navsLengths).length >= 10) {
         postMessage({ requestId: data.requestId, navsLengths: navsLengths });

--- a/src/workers/item_length_worker.js
+++ b/src/workers/item_length_worker.js
@@ -11,6 +11,7 @@ addEventListener("message", (e) => {
 
   /* 全体のTotalLength */
   postMessage({
+    requestId: data.requestId,
     allTotalLength: allTotalLength({
       isFullMode: data.isFullMode,
       partnerlist: data.partnerlist,
@@ -19,6 +20,7 @@ addEventListener("message", (e) => {
 
   /* 全体のCollectedLength */
   postMessage({
+    requestId: data.requestId,
     allCollectedLength: allCollectedLength({
       collected: data.collected,
       isFullMode: data.isFullMode,
@@ -67,17 +69,17 @@ addEventListener("message", (e) => {
       }
       /* nav単位で送信すると特にAndroidでCollectedLengthの更新遅延が発生する。そのため、ある程度まとめて送信する。 */
       if (Object.keys(navsLengths).length >= 10) {
-        postMessage({ navsLengths: navsLengths });
+        postMessage({ requestId: data.requestId, navsLengths: navsLengths });
         navsLengths = {};
       }
     });
 
   /* nav別の未送信分を送信 */
   if (Object.keys(navsLengths).length > 0) {
-    postMessage({ navLengths: navsLengths });
+    postMessage({ requestId: data.requestId, navLengths: navsLengths });
   }
 
-  return postMessage({ complete: true });
+  return postMessage({ requestId: data.requestId, complete: true });
 });
 
 export default {};

--- a/src/workers/item_length_worker.js
+++ b/src/workers/item_length_worker.js
@@ -1,0 +1,83 @@
+import {
+  totalLength,
+  collectedLength,
+  allTotalLength,
+  allCollectedLength,
+} from "../utils/filterItems";
+import { navs } from "../utils/navs";
+
+addEventListener("message", (e) => {
+  const { data } = e;
+
+  /* 全体のTotalLength */
+  postMessage({
+    allTotalLength: allTotalLength({
+      isFullMode: data.isFullMode,
+      partnerlist: data.partnerlist,
+    }),
+  });
+
+  /* 全体のCollectedLength */
+  postMessage({
+    allCollectedLength: allCollectedLength({
+      collected: data.collected,
+      isFullMode: data.isFullMode,
+      partnerlist: data.partnerlist,
+    }),
+  });
+
+  /* nav別のTotalLengthとCollectedLength */
+  let navsLengths = {};
+  navs
+    .filter((nav) => {
+      return nav.id !== "exchange" && nav.id.indexOf("separator");
+    })
+    .forEach((nav) => {
+      const subnavs = nav.subnavs;
+      if (subnavs) {
+        subnavs.forEach((subnav) => {
+          navsLengths[subnav.id] = [
+            totalLength({
+              nav: subnav.id,
+              isFullMode: data.isFullMode,
+              partnerlist: data.partnerlist,
+            }),
+            collectedLength({
+              nav: subnav.id,
+              collected: data.collected,
+              isFullMode: data.isFullMode,
+              partnerlist: data.partnerlist,
+            }),
+          ];
+        });
+      } else {
+        navsLengths[nav.id] = [
+          totalLength({
+            nav: nav.id,
+            isFullMode: data.isFullMode,
+            partnerlist: data.partnerlist,
+          }),
+          collectedLength({
+            nav: nav.id,
+            collected: data.collected,
+            isFullMode: data.isFullMode,
+            partnerlist: data.partnerlist,
+          }),
+        ];
+      }
+      /* nav単位で送信すると特にAndroidでCollectedLengthの更新遅延が発生する。そのため、ある程度まとめて送信する。 */
+      if (Object.keys(navsLengths).length >= 10) {
+        postMessage({ navsLengths: navsLengths });
+        navsLengths = {};
+      }
+    });
+
+  /* nav別の未送信分を送信 */
+  if (Object.keys(navsLengths).length > 0) {
+    postMessage({ navLengths: navsLengths });
+  }
+
+  return postMessage({ complete: true });
+});
+
+export default {};


### PR DESCRIPTION
手元のAndroid端末だとコンプ率計算が遅く、多少ストレスを感じるため、改善PRを作成しました。

コンプ率0％での計算時間（Androidはやけに遅いです…）
・Android9端末（moto g8 plus：2年半前ぐらいのモデル） → 約11秒
・Android11端末（pixel 5a：半年前ぐらいのモデル） → 約5秒
・iPhone SE2 → 約1秒

計算自体を簡単に速くするのは難しそうだったため、以下の方針としました。
・計算が終わったカテゴリから順次表示する
・進捗バーや取得数を動的に書き換えて（アニメーションさせて）飽きさせないようにする

UI更新に影響が出ないよう、コンプ率は別スレッド（WebWorker）で計算するようにしています。
ただ、WebWorkerはUIスレッドとは実行コンテキストが異なり
storeに保存してあるデータが取得できないため、
計算ロジックがあるモジュール（filterItems.js）からstoreを見ないようにする対応も行っています。
→ 関連コミット c6e2395beefd6e2d84685a1e08f031c2b42b420f 
